### PR TITLE
hide overflow of masthead to prevent large cover images from peeking …

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -345,6 +345,7 @@ body.article-page .container {
     margin: 0;
     padding: 0;
     height: 400px;
+    overflow: hidden;
     position: fixed;
     z-index: -1;
 }


### PR DESCRIPTION
…from bottom